### PR TITLE
Require the curl extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   },
   "require": {
     "php": ">=7.0",
+    "ext-curl": "*",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
By requiring the curl extension at the installation step users don't get unwanted errors when the curl extension is missing (which is highly unlikely) and they try to use cigar.